### PR TITLE
Fix checkptr error

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -20,7 +20,7 @@ jobs:
     - name: checkout
       uses: actions/checkout@v2
     - name: test
-      run: go test -v ./ -count=1
+      run: go test -race -v ./ -count=1
       env:
         CC: clang
         CXX: clang++

--- a/internal/helper/bind.go
+++ b/internal/helper/bind.go
@@ -55,6 +55,10 @@ func PtrToSlice(p unsafe.Pointer, cb func(unsafe.Pointer)) {
 	}
 }
 
+func IntPtr(v int) unsafe.Pointer {
+	return *(*unsafe.Pointer)(unsafe.Pointer(&v))
+}
+
 func SliceToPtr(v interface{}, cb func(int) unsafe.Pointer) unsafe.Pointer {
 	rv := reflect.ValueOf(v)
 	slice := (*reflect.SliceHeader)(C.malloc(C.ulong(unsafe.Sizeof(reflect.SliceHeader{}))))

--- a/language_options.go
+++ b/language_options.go
@@ -52,7 +52,7 @@ func (o *LanguageOptions) SupportsStatementKind(kind resolved_ast.Kind) bool {
 // explicitly opt in to support other statements.
 func (o *LanguageOptions) SetSupportedStatementKinds(kinds []resolved_ast.Kind) {
 	internal.LanguageOptions_SetSupportedStatementKinds(o.raw, helper.SliceToPtr(kinds, func(i int) unsafe.Pointer {
-		return unsafe.Pointer(uintptr(int(kinds[i])))
+		return helper.IntPtr(int(kinds[i]))
 	}))
 }
 
@@ -91,7 +91,7 @@ func (o *LanguageOptions) EnableLanguageFeature(feature LanguageFeature) {
 
 func (o *LanguageOptions) SetEnabledLanguageFeatures(features []LanguageFeature) {
 	internal.LanguageOptions_SetEnabledLanguageFeatures(o.raw, helper.SliceToPtr(features, func(i int) unsafe.Pointer {
-		return unsafe.Pointer(uintptr(int(features[i])))
+		return helper.IntPtr(int(features[i]))
 	}))
 }
 


### PR DESCRIPTION
```
$ go test -race ./
fatal error: checkptr: pointer arithmetic computed bad pointer value

goroutine 19 [running]:
runtime.throw({0x105c9577b?, 0x1049911e0?})
        /Users/goccy/sdk/go1.19/src/runtime/panic.go:1047 +0x40 fp=0xc000067b70 sp=0xc000067b40 pc=0x1049c0290
runtime.checkptrArithmetic(0x107326e40?, {0x0?, 0xc000067be8?, 0x104991058?})
        /Users/goccy/sdk/go1.19/src/runtime/checkptr.go:52 +0xbc fp=0xc000067ba0 sp=0xc000067b70 pc=0x10499115c
github.com/goccy/go-zetasql.(*LanguageOptions).SetSupportedStatementKinds.func1(0x0)
        /Users/goccy/Development/goccy/go-zetasql/language_options.go:55 +0x74 fp=0xc000067bf0 sp=0xc000067ba0 pc=0x104bd9a54
github.com/goccy/go-zetasql/internal/helper.SliceToPtr.func1(0x20?, 0xc000067c88, 0xc000067d18)
        /Users/goccy/Development/goccy/go-zetasql/internal/helper/bind.go:71 +0x58 fp=0xc000067c40 sp=0xc000067bf0 pc=0x104acf508
github.com/goccy/go-zetasql/internal/helper.SliceToPtr({0x1060e4140, 0xc0001c0078}, 0x4?)
        /Users/goccy/Development/goccy/go-zetasql/internal/helper/bind.go:71 +0x33c fp=0xc000067cf0 sp=0xc000067c40 pc=0x104acf3fc
github.com/goccy/go-zetasql.(*LanguageOptions).SetSupportedStatementKinds(0xc0001a23d0, {0xc0001de080, 0x4, 0x4})
        /Users/goccy/Development/goccy/go-zetasql/language_options.go:54 +0x80 fp=0xc000067d40 sp=0xc000067cf0 pc=0x104bd9980
github.com/goccy/go-zetasql_test.TestAnalyzer(0xc000182ea0)
        /Users/goccy/Development/goccy/go-zetasql/analyzer_test.go:38 +0x2dc fp=0xc000067e90 sp=0xc000067d40 pc=0x104bdbeac
```