### PR TITLE
SimpleTypeNode.TypeName returns *PathExpressionNode

### DIFF
--- a/ast/node.go
+++ b/ast/node.go
@@ -1376,10 +1376,10 @@ type SimpleTypeNode struct {
 	*TypeBaseNode
 }
 
-func (n *SimpleTypeNode) TypeName() string {
+func (n *SimpleTypeNode) TypeName() *PathExpressionNode {
 	var v unsafe.Pointer
 	internal.ASTSimpleType_type_name(n.getRaw(), &v)
-	return helper.PtrToString(v)
+	return newPathExpressionNode(v)
 }
 
 type ArrayTypeNode struct {


### PR DESCRIPTION
fix #37 

I think SimpleTypeNode.TypeName should return PathExpressionNode. https://github.com/goccy/go-zetasql/blob/main/internal/ccall/zetasql/parser/parse_tree_generated.h#L1183

